### PR TITLE
Cloudwatch -> CloudWatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Vue Cloudwatch Dashboard
+# Vue CloudWatch Dashboard
 
 ![Screenshot](img/screenshot.png)
 


### PR DESCRIPTION
It's `CloudWatch` elsewhere, no harm in being consistent.